### PR TITLE
Use label text for image title when label hidden

### DIFF
--- a/buttonbox/templates/buttons/field.html
+++ b/buttonbox/templates/buttons/field.html
@@ -9,7 +9,7 @@
     {% set optionDisabled = (option.disabled is defined ? option.disabled : false) %}
     <label class="btn  big{% if optionValue == value %} active{% endif %}">
       <input type="radio" name="{{ name }}" value="{{ optionValue }}"{% if optionValue == value %} checked="checked"{% endif %}{% if optionDisabled %} disabled{% endif %}>
-      {% if option.imageUrl %}<img src="{{ option.imageUrl }}"{% if option.showLabel %} class="buttonbox-buttons__with-label"{% endif %} />{% endif %}
+      {% if option.imageUrl %}<img src="{{ option.imageUrl }}"{% if option.showLabel %} class="buttonbox-buttons__with-label"{% endif %} {% if not option.showLabel %} title="{{ optionLabel }}"{% endif %} />{% endif %}
       {% if option.imageUrl and option.showLabel %}&nbsp;{% endif %}
       {% if option.showLabel %}<span class="buttonbox-buttons__label">{{ optionLabel }}</span>{% endif %}
     </label>


### PR DESCRIPTION
When buttons have the 'Show Label?' set to false, use the Option Label text as a `title` attribute for the icon images instead, so it is displayed as a browser tool-tip.